### PR TITLE
Fix deprecation warning from Crypto library

### DIFF
--- a/lib/gzip.dart
+++ b/lib/gzip.dart
@@ -1,15 +1,9 @@
 part of ice;
 
 class Gzip {
-  static String encode(String string) {
-    var gzip = js.context['RawDeflate'].callMethod('deflate', [string]);
-    return CryptoUtils.bytesToBase64(gzip.codeUnits);
-  }
+  static String encode(String string) =>
+    js.context['RawDeflate'].callMethod('deflateToBase64', [string]);
 
-  static String decode(String string) {
-    // var bytes = CryptoUtils.base64StringToBytes(string);
-    // var gzip = new String.fromCharCodes(bytes);
-    // return js.context.RawDeflate.inflate(gzip);
-    return js.context['RawDeflate'].callMethod('inflateFromBase64', [string]);
-  }
+  static String decode(String string) =>
+    js.context['RawDeflate'].callMethod('inflateFromBase64', [string]);
 }

--- a/lib/ice.dart
+++ b/lib/ice.dart
@@ -6,8 +6,6 @@ import 'dart:convert';
 import 'dart:html';
 import 'dart:js' as js;
 
-import 'package:crypto/crypto.dart';
-
 import 'package:ctrl_alt_foo/keys.dart';
 
 part 'editor.dart';

--- a/lib/js/deflate/rawdeflate.js
+++ b/lib/js/deflate/rawdeflate.js
@@ -1665,7 +1665,7 @@ var zip_deflate = function(str, level) {
     return aout.join("");
 }
 
-if (! window.RawDeflate) RawDeflate = {};
+if (!window.RawDeflate) RawDeflate = {};
 RawDeflate.deflate = zip_deflate;
 RawDeflate.deflateToBase64 = function(str) {
   return btoa(zip_deflate(str));

--- a/lib/js/deflate/rawdeflate.js
+++ b/lib/js/deflate/rawdeflate.js
@@ -1667,5 +1667,7 @@ var zip_deflate = function(str, level) {
 
 if (! window.RawDeflate) RawDeflate = {};
 RawDeflate.deflate = zip_deflate;
-
+RawDeflate.deflateToBase64 = function(str) {
+  return btoa(zip_deflate(str));
+}
 })();

--- a/lib/js/deflate/rawinflate.js
+++ b/lib/js/deflate/rawinflate.js
@@ -747,7 +747,7 @@ var zip_inflate = function(str) {
     return aout.join("");
 }
 
-if (! window.RawDeflate) RawDeflate = {};
+if (!window.RawDeflate) RawDeflate = {};
 RawDeflate.inflate = zip_inflate;
 RawDeflate.inflateFromBase64 = function(str) {
   return zip_inflate(atob(str));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,6 @@ description: Code Editor + Preview
 homepage: https://github.com/eee-c/ice-code-editor
 dependencies:
   browser: '>=0.10.0 <0.11.0'
-  crypto: '>=0.9.0 < 0.10.0'
   ctrl_alt_foo: '>=0.3.1 <0.3.2'
   ace: ">=0.5.0 <0.6.0"
   # polymer: any

--- a/test/test_runner.sh
+++ b/test/test_runner.sh
@@ -10,7 +10,7 @@ results_ignoring_ok_deprecations=$(
     grep -v "hints found.$"
 )
 echo "$results_ignoring_ok_deprecations"
-count=$(echo "$results_ignoring_ok_deprecations" | wc -l)
+count=$(echo "$results_ignoring_ok_deprecations" | wc -l | tr -d " ")
 if [[ "$count" != "1" ]]
 then
   exit 1

--- a/test/test_runner.sh
+++ b/test/test_runner.sh
@@ -4,7 +4,6 @@
 results=$(dartanalyzer lib/ice.dart 2>&1)
 results_ignoring_ok_deprecations=$(
   echo "$results" | \
-    grep -v "'CryptoUtils' is deprecated" | \
     grep -v "'query' is deprecated" | \
     grep -v "'queryAll' is deprecated" | \
     grep -v "hints found.$"


### PR DESCRIPTION
Fixes #106.

We now use native JavaScript's `atob` and `btoa` functions that convert a
string to and from Base64 representation. The vendored package `RawDeflate` is
used for deflating and inflating the string into bytes.

Depends on #110.
